### PR TITLE
Remember current page numbers between comics

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -275,5 +275,14 @@ Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
       <property name="illegalPattern" value="true"/>
       <property name="message" value="Trailing whitespace"/>
     </module>
+    <module name="FinalLocalVariable">
+      <property name="tokens" value="VARIABLE_DEF, PARAMETER_DEF"/>
+      <property name="validateEnhancedForLoopVariable" value="true"/>
+    </module>
+    <module name="LocalFinalVariableName"/>
+    <module name="UnusedImports"/>
+    <module name="StaticVariableName"/>
+    <module name="IllegalImport"/>
+    <module name="RedundantImport"/>
   </module>
 </module>

--- a/src/main/java/de/wasenweg/alfred/comics/ComicController.java
+++ b/src/main/java/de/wasenweg/alfred/comics/ComicController.java
@@ -33,12 +33,11 @@ public class ComicController {
   @Autowired
   private ComicQueryRepositoryImpl queryRepository;
 
-  @Autowired
-  private ComicRepository comicRepository;
-
   @GetMapping("/{comicId}")
-  public Resource<Comic> findById(@PathVariable("comicId") final String comicId) {
-    return addLink(this.comicRepository.findById(comicId));
+  public Resource<Comic> findById(
+      final Principal principal,
+      @PathVariable("comicId") final String comicId) {
+    return addLink(this.queryRepository.findById(principal.getName(), comicId));
   }
 
   @GetMapping("/search/findAllLastReadPerVolume")

--- a/src/main/java/de/wasenweg/alfred/comics/ComicQueryRepository.java
+++ b/src/main/java/de/wasenweg/alfred/comics/ComicQueryRepository.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 
 public interface ComicQueryRepository {
 
+  Optional<Comic> findById(final String userId, final String comicId);
+
   Optional<Comic> findLastReadForVolume(
       final String userId,
       final String publisher,

--- a/src/main/java/de/wasenweg/alfred/comics/ComicQueryRepositoryImpl.java
+++ b/src/main/java/de/wasenweg/alfred/comics/ComicQueryRepositoryImpl.java
@@ -2,6 +2,7 @@ package de.wasenweg.alfred.comics;
 
 import de.wasenweg.alfred.progress.ProgressHelper;
 
+import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -27,6 +28,16 @@ public class ComicQueryRepositoryImpl implements ComicQueryRepository {
 
   @Autowired
   private MongoTemplate mongoTemplate;
+
+  @Override
+  public Optional<Comic> findById(
+      final String userId,
+      final String comicId) {
+    return Optional.ofNullable(mongoTemplate.aggregate(ProgressHelper.aggregateWithProgress(userId,
+        match(where("_id").is(new ObjectId(comicId))),
+        limit(1)
+        ), Comic.class, Comic.class).getUniqueMappedResult());
+  }
 
   // Lists issues for volumes that are in progress, aka bookmarks.
   @Override

--- a/src/test/java/de/wasenweg/alfred/ScannerAssociationIngrationTest.java
+++ b/src/test/java/de/wasenweg/alfred/ScannerAssociationIngrationTest.java
@@ -53,10 +53,10 @@ public class ScannerAssociationIngrationTest {
         .verify();
 
     // Then
-    List<Comic> comics = comicRepository.findAll();
+    final List<Comic> comics = comicRepository.findAll();
     assertThat(comics.size()).isEqualTo(305);
 
-    List<Comic> batgirlVol2008 = comicRepository
+    final List<Comic> batgirlVol2008 = comicRepository
         .findAllByPublisherAndSeriesAndVolumeOrderByPosition("", "DC Comics", "Batgirl", "2008");
     assertThat(batgirlVol2008.size()).isEqualTo(6);
 

--- a/src/test/java/de/wasenweg/alfred/ScannerIngrationTest.java
+++ b/src/test/java/de/wasenweg/alfred/ScannerIngrationTest.java
@@ -54,7 +54,7 @@ public class ScannerIngrationTest {
         .verify(Duration.ofSeconds(2L));
 
     // Then
-    List<Comic> comics = comicRepository.findAll();
+    final List<Comic> comics = comicRepository.findAll();
     assertThat(comics.size()).isEqualTo(1);
   }
 }

--- a/ui/angular.json
+++ b/ui/angular.json
@@ -115,6 +115,11 @@
                 "input": "src/assets",
                 "output": "/assets"
               },
+              {
+                "glob": "**/*",
+                "input": "node_modules/ionicons/dist/ionicons/svg",
+                "output": "/svg"
+              },
               "src/manifest.json"
             ]
           },

--- a/ui/e2e/src/issues.po.ts
+++ b/ui/e2e/src/issues.po.ts
@@ -1,4 +1,4 @@
-import { browser, by, element, ElementFinder } from 'protractor';
+import { by, element } from 'protractor';
 import { Page } from './page.po';
 
 export class IssuesPage {

--- a/ui/e2e/src/library.po.ts
+++ b/ui/e2e/src/library.po.ts
@@ -1,4 +1,4 @@
-import { browser, by, element, ElementFinder } from 'protractor';
+import { browser, by, element } from 'protractor';
 import { Page } from './page.po';
 
 export class LibraryPage {

--- a/ui/src/app/app.component.spec.ts
+++ b/ui/src/app/app.component.spec.ts
@@ -1,12 +1,11 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { Platform } from '@ionic/angular';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SplashScreen } from '@ionic-native/splash-screen/ngx';
 import { StatusBar } from '@ionic-native/status-bar/ngx';
 
-import { TestModule } from './../testing/test.module';
 import { UserServiceMocks as userService } from './../testing/user.service.mocks';
 
 import { UserService } from './user.service';
@@ -18,7 +17,7 @@ describe('AppComponent', () => {
   let component: AppComponent;
   let fixture: ComponentFixture<AppComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     statusBarSpy = jasmine.createSpyObj('StatusBar', ['styleDefault']);
     splashScreenSpy = jasmine.createSpyObj('SplashScreen', ['hide']);
     platformReadySpy = Promise.resolve();
@@ -34,10 +33,7 @@ describe('AppComponent', () => {
         { provide: UserService, useValue: userService }
       ],
       imports: [ RouterTestingModule.withRoutes([])],
-    }).compileComponents();
-  }));
-
-  beforeEach(() => {
+    });
     fixture = TestBed.createComponent(AppComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/ui/src/app/auth.guard.spec.ts
+++ b/ui/src/app/auth.guard.spec.ts
@@ -1,5 +1,5 @@
 import { Router, ActivatedRouteSnapshot } from '@angular/router';
-import { TestBed, async, inject } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 
 import { UserService } from './user.service';

--- a/ui/src/app/bookmarks/bookmark-actions/bookmark-actions.component.spec.ts
+++ b/ui/src/app/bookmarks/bookmark-actions/bookmark-actions.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NavParams } from '@ionic/angular';
 
 import { TestModule } from '../../../testing/test.module';
@@ -11,16 +11,13 @@ describe('BookmarkActionsComponent', () => {
   let fixture: ComponentFixture<BookmarkActionsComponent>;
   let navParams: NavParams;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     navParams = new NavParams({ comic });
     const testModule: any = TestModule();
     testModule.providers.push({
       provide: NavParams, useValue: navParams
     });
-    TestBed.configureTestingModule(testModule).compileComponents();
-  }));
-
-  beforeEach(() => {
+    TestBed.configureTestingModule(testModule);
     fixture = TestBed.createComponent(BookmarkActionsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/ui/src/app/bookmarks/bookmark-actions/bookmark-actions.component.ts
+++ b/ui/src/app/bookmarks/bookmark-actions/bookmark-actions.component.ts
@@ -18,7 +18,7 @@ export class BookmarkActionsComponent {
     private router: Router,
     private navParams: NavParams
   ) {
-    this.comic = navParams.get('comic');
+    this.comic = this.navParams.get('comic');
   }
 
   goToVolume (comic: Comic): void {

--- a/ui/src/app/bookmarks/bookmarks.page.spec.ts
+++ b/ui/src/app/bookmarks/bookmarks.page.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TestModule } from '../../testing/test.module';
 import { ComicsServiceMocks as comicsService } from '../../testing/comics.service.mocks';
@@ -10,15 +10,12 @@ describe('BookmarksPage', () => {
   let component: BookmarksPage;
   let fixture: ComponentFixture<BookmarksPage>;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     const testModule: any = TestModule();
     testModule.providers.push({
       provide: ComicsService, useValue: comicsService
     });
-    TestBed.configureTestingModule(testModule).compileComponents();
-  }));
-
-  beforeEach(() => {
+    TestBed.configureTestingModule(testModule);
     fixture = TestBed.createComponent(BookmarksPage);
     component = fixture.componentInstance;
     component.ionViewDidEnter();

--- a/ui/src/app/bookmarks/bookmarks.page.ts
+++ b/ui/src/app/bookmarks/bookmarks.page.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { Router } from '@angular/router';
 import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
 import { PopoverController } from '@ionic/angular';
 
@@ -17,7 +16,6 @@ export class BookmarksPage {
   comics: Comic[];
 
   constructor (
-    private router: Router,
     private comicsService: ComicsService,
     private sanitizer: DomSanitizer,
     private popoverController: PopoverController

--- a/ui/src/app/issues/issue-actions/issue-actions.component.spec.ts
+++ b/ui/src/app/issues/issue-actions/issue-actions.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NavParams } from '@ionic/angular';
 
 import { TestModule } from '../../../testing/test.module';
@@ -11,16 +11,13 @@ describe('IssueActionsComponent', () => {
   let fixture: ComponentFixture<IssueActionsComponent>;
   let navParams: NavParams;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     navParams = new NavParams({ comic });
     const testModule: any = TestModule();
     testModule.providers.push({
       provide: NavParams, useValue: navParams
     });
-    TestBed.configureTestingModule(testModule).compileComponents();
-  }));
-
-  beforeEach(() => {
+    TestBed.configureTestingModule(testModule);
     fixture = TestBed.createComponent(IssueActionsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/ui/src/app/issues/issue-actions/issue-actions.component.ts
+++ b/ui/src/app/issues/issue-actions/issue-actions.component.ts
@@ -18,7 +18,7 @@ export class IssueActionsComponent {
     private router: Router,
     private navParams: NavParams
   ) {
-    this.comic = navParams.get('comic');
+    this.comic = this.navParams.get('comic');
   }
 
   download () {

--- a/ui/src/app/issues/issues.page.spec.ts
+++ b/ui/src/app/issues/issues.page.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TestModule } from '../../testing/test.module';
 import { ComicsServiceMocks as comicsService } from '../../testing/comics.service.mocks';
@@ -10,15 +10,12 @@ describe('IssuesPage', () => {
   let component: IssuesPage;
   let fixture: ComponentFixture<IssuesPage>;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     const testModule: any = TestModule();
     testModule.providers.push({
       provide: ComicsService, useValue: comicsService
     });
-    TestBed.configureTestingModule(testModule).compileComponents();
-  }));
-
-  beforeEach(() => {
+    TestBed.configureTestingModule(testModule);
     fixture = TestBed.createComponent(IssuesPage);
     component = fixture.componentInstance;
     component.ionViewDidEnter();

--- a/ui/src/app/library/publishers/publishers.component.spec.ts
+++ b/ui/src/app/library/publishers/publishers.component.spec.ts
@@ -1,5 +1,4 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TestModule } from '../../../testing/test.module';
 import { VolumesServiceMocks as volumesService } from '../../../testing/volumes.service.mocks';
@@ -11,15 +10,12 @@ describe('PublishersComponent', () => {
   let component: PublishersComponent;
   let fixture: ComponentFixture<PublishersComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     const testModule: any = TestModule();
     testModule.providers.push({
       provide: VolumesService, useValue: volumesService
     });
-    TestBed.configureTestingModule(testModule).compileComponents();
-  }));
-
-  beforeEach(() => {
+    TestBed.configureTestingModule(testModule);
     fixture = TestBed.createComponent(PublishersComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/ui/src/app/library/series/series.component.spec.ts
+++ b/ui/src/app/library/series/series.component.spec.ts
@@ -1,5 +1,4 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TestModule } from '../../../testing/test.module';
 import { VolumesServiceMocks as volumesService } from '../../../testing/volumes.service.mocks';
@@ -11,15 +10,12 @@ describe('SeriesComponent', () => {
   let component: SeriesComponent;
   let fixture: ComponentFixture<SeriesComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     const testModule: any = TestModule();
     testModule.providers.push({
       provide: VolumesService, useValue: volumesService
     });
-    TestBed.configureTestingModule(testModule).compileComponents();
-  }));
-
-  beforeEach(() => {
+    TestBed.configureTestingModule(testModule);
     fixture = TestBed.createComponent(SeriesComponent);
     component = fixture.componentInstance;
     component.ionViewDidEnter();

--- a/ui/src/app/library/volumes/volume-actions/volume-actions.component.spec.ts
+++ b/ui/src/app/library/volumes/volume-actions/volume-actions.component.spec.ts
@@ -1,27 +1,23 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NavParams } from '@ionic/angular';
 
 import { TestModule } from '../../../../testing/test.module';
 import { volume1 as volume } from '../../../../testing/volume.fixtures';
 
 import { VolumeActionsComponent } from './volume-actions.component';
-import { Volume } from '../../../volume';
 
 describe('VolumeActionsComponent', () => {
   let component: VolumeActionsComponent;
   let fixture: ComponentFixture<VolumeActionsComponent>;
   let navParams: NavParams;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     navParams = new NavParams({ volume });
     const testModule: any = TestModule();
     testModule.providers.push({
       provide: NavParams, useValue: navParams
     });
-    TestBed.configureTestingModule(testModule).compileComponents();
-  }));
-
-  beforeEach(() => {
+    TestBed.configureTestingModule(testModule);
     fixture = TestBed.createComponent(VolumeActionsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/ui/src/app/library/volumes/volume-actions/volume-actions.component.ts
+++ b/ui/src/app/library/volumes/volume-actions/volume-actions.component.ts
@@ -18,7 +18,7 @@ export class VolumeActionsComponent {
     private volumesService: VolumesService,
     private navParams: NavParams
   ) {
-    this.volume = navParams.get('volume');
+    this.volume = this.navParams.get('volume');
   }
 
   public markAsRead (volume: Volume) {

--- a/ui/src/app/library/volumes/volumes.component.spec.ts
+++ b/ui/src/app/library/volumes/volumes.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TestModule } from '../../../testing/test.module';
 import { VolumesServiceMocks as volumesService } from '../../../testing/volumes.service.mocks';
@@ -10,15 +10,12 @@ describe('VolumesComponent', () => {
   let component: VolumesComponent;
   let fixture: ComponentFixture<VolumesComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     const testModule: any = TestModule();
     testModule.providers.push({
       provide: VolumesService, useValue: volumesService
     });
-    TestBed.configureTestingModule(testModule).compileComponents();
-  }));
-
-  beforeEach(() => {
+    TestBed.configureTestingModule(testModule);
     fixture = TestBed.createComponent(VolumesComponent);
     component = fixture.componentInstance;
     component.ionViewDidEnter();

--- a/ui/src/app/login/login.page.spec.ts
+++ b/ui/src/app/login/login.page.spec.ts
@@ -1,5 +1,4 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TestModule } from '../../testing/test.module';
 import { UserServiceMocks as userService } from '../../testing/user.service.mocks';
@@ -11,15 +10,12 @@ describe('LoginPage', () => {
   let component: LoginPage;
   let fixture: ComponentFixture<LoginPage>;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     const testModule: any = TestModule();
     testModule.providers.push({
       provide: UserService, useValue: userService
     });
-    TestBed.configureTestingModule(testModule).compileComponents();
-  }));
-
-  beforeEach(() => {
+    TestBed.configureTestingModule(testModule);
     fixture = TestBed.createComponent(LoginPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/ui/src/app/reader/reader.page.html
+++ b/ui/src/app/reader/reader.page.html
@@ -3,11 +3,11 @@
   (swipeleft)="onSwipe(1)"
   (swiperight)="onSwipe(-1)">
   <div class="wrapper" *ngIf="imagePathLeft">
-    <img [src]="imagePathLeft | secure | async" class="left"
+    <img [attr.src]="imagePathLeft | secure | async" class="left"
          alt="{{ comic.title }} # {{ comic.number }}">
   </div>
   <div class="wrapper" *ngIf="imagePathRight">
-    <img [src]="imagePathRight | secure | async" class="right"
+    <img [attr.src]="imagePathRight | secure | async" class="right"
          alt="{{ comic.title }} # {{ comic.number }}">
   </div>
 </div>

--- a/ui/src/app/reader/reader.page.sass
+++ b/ui/src/app/reader/reader.page.sass
@@ -46,7 +46,6 @@
 
     .wrapper
       height: 100vh
-      margin: 0 auto
 
       img
         max-width: 100%

--- a/ui/src/app/reader/reader.page.spec.ts
+++ b/ui/src/app/reader/reader.page.spec.ts
@@ -74,6 +74,7 @@ describe('ReaderPage', () => {
 
     fixture = TestBed.createComponent(ReaderPage);
     component = fixture.componentInstance;
+    component.ionViewDidEnter();
     fixture.detectChanges();
   });
 

--- a/ui/src/app/reader/reader.page.spec.ts
+++ b/ui/src/app/reader/reader.page.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router, ActivatedRoute } from '@angular/router';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -38,7 +38,7 @@ describe('ReaderPage', () => {
       });
   };
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     router = jasmine.createSpyObj('Router', ['navigate']);
 
     const testModule: any = TestModule();
@@ -65,10 +65,8 @@ describe('ReaderPage', () => {
       ])
     );
 
-    TestBed.configureTestingModule(testModule).compileComponents();
-  }));
+    TestBed.configureTestingModule(testModule);
 
-  beforeEach(() => {
     // Allow steering ComicsService response:
     comicsService.get.and.returnValue(defer(() => Promise.resolve(comic)));
 

--- a/ui/src/app/reader/reader.page.ts
+++ b/ui/src/app/reader/reader.page.ts
@@ -117,9 +117,6 @@ export class ReaderPage {
           queryParamsHandling: 'merge'
         });
         this.imagePathLeft = `/api/read/${ this.comic.id }/${ NavigatorService.page }`;
-        // FIXME When `sideBySide` is `false`, `this.imagePathRight` is `null` but is still
-        // rendered in the view, resulting in error:
-        // `GET http://localhost:4200/null 404 (Not Found)`.
         this.imagePathRight = instruction.sideBySide ? `/api/read/${ this.comic.id }/${ NavigatorService.page + 1 }` : null;
         break;
       case AdjacentComic.next:

--- a/ui/src/app/reader/reader.page.ts
+++ b/ui/src/app/reader/reader.page.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, ElementRef, HostListener, OnInit } from '@angular/core';
+import { Component, ViewChild, ElementRef, HostListener } from '@angular/core';
 import { ToastController } from '@ionic/angular';
 import { ActivatedRoute, Router } from '@angular/router';
 

--- a/ui/src/app/settings/scanner/scanner.component.spec.ts
+++ b/ui/src/app/settings/scanner/scanner.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TestModule } from '../../../testing/test.module';
 
@@ -11,15 +11,12 @@ describe('ScannerComponent', () => {
   let component: ScannerComponent;
   let fixture: ComponentFixture<ScannerComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     const testModule: any = TestModule();
     testModule.providers.push({
       provide: StatsService, useValue: statsService
     });
-    TestBed.configureTestingModule(testModule).compileComponents();
-  }));
-
-  beforeEach(() => {
+    TestBed.configureTestingModule(testModule);
     fixture = TestBed.createComponent(ScannerComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/ui/src/app/settings/settings.page.spec.ts
+++ b/ui/src/app/settings/settings.page.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TestModule } from '../../testing/test.module';
 import { SettingsServiceMocks as settingsService } from '../../testing/settings.service.mocks';
@@ -13,7 +13,7 @@ describe('SettingsPage', () => {
   let component: SettingsPage;
   let fixture: ComponentFixture<SettingsPage>;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     const testModule: any = TestModule();
     testModule.providers.push({
       provide: SettingsService, useValue: settingsService
@@ -21,10 +21,7 @@ describe('SettingsPage', () => {
     testModule.providers.push({
       provide: StatsService, useValue: statsService
     });
-    TestBed.configureTestingModule(testModule).compileComponents();
-  }));
-
-  beforeEach(() => {
+    TestBed.configureTestingModule(testModule);
     fixture = TestBed.createComponent(SettingsPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/ui/src/app/user.service.ts
+++ b/ui/src/app/user.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NgZone } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject } from 'rxjs';
 
 import { User } from './user';

--- a/ui/src/app/volumes.service.ts
+++ b/ui/src/app/volumes.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, GroupedObservable } from 'rxjs';
-import { map, groupBy } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 import { Publisher } from './publisher';
 import { Series } from './series';

--- a/ui/tslint.json
+++ b/ui/tslint.json
@@ -74,6 +74,7 @@
     "no-trailing-whitespace": true,
     "no-unnecessary-initializer": true,
     "no-unused-expression": true,
+    "no-unused-variable": true,
     "no-use-before-declare": true,
     "no-var-keyword": true,
     "object-curly-spacing": true,


### PR DESCRIPTION
* [x] Remember current page numbers between comics.
* [x] Get rid of `/null` GETs.
* [x] Side by side read mode: Place comic pages in the center, next to each other.
* [x] Make sure all end points return user aggregated comics.
* [x] Display toast when navigating between comics automatically.