### PR TITLE
Replace docker gradle plugin

### DIFF
--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -9,6 +9,10 @@ node {
   download = true
 }
 
+npm_update {
+  args = ['--production', '--loglevel', 'warn']
+}
+
 jar.dependsOn 'npm_run_buildProd'
 
 jar {


### PR DESCRIPTION
With these changes, the application can be built just using Docker - without the need for Java or Gradle on the host system.